### PR TITLE
Switch to lwjgl3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ project(":desktop") {
         implementation project(":gdx-graph-models-design")
         implementation project(":gdx-graph-lighting3d-design")
 
-        api "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+        api "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
     }
 }
@@ -84,7 +84,7 @@ project(":gdx-graph-test") {
 
     dependencies {
         implementation project(":gdx-graph-util")
-        api "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+        api "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
         api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"

--- a/desktop/src/com/gempukku/libgdx/graph/desktop/DesktopLauncher.java
+++ b/desktop/src/com/gempukku/libgdx/graph/desktop/DesktopLauncher.java
@@ -1,8 +1,8 @@
 package com.gempukku.libgdx.graph.desktop;
 
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
 import com.gempukku.libgdx.graph.plugin.callback.design.RenderCallbackPluginDesignInitializer;
@@ -26,10 +26,10 @@ public class DesktopLauncher {
     public static void main(String[] arg) throws IOException {
         setupPlugins();
 
-        LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-        config.width = 1440;
-        config.height = 810;
-        new LwjglApplication(new LibgdxGraphApplication(), config);
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setWindowedMode(1440, 810);
+        LibgdxGraphApplication application = new LibgdxGraphApplication();
+        new Lwjgl3Application(application, config);
     }
 
     private static void setupPlugins() throws MalformedURLException {

--- a/gdx-graph-test/src/com/gempukku/libgdx/graph/test/TestDesktopLauncher.java
+++ b/gdx-graph-test/src/com/gempukku/libgdx/graph/test/TestDesktopLauncher.java
@@ -1,13 +1,12 @@
 package com.gempukku.libgdx.graph.test;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 
 public class TestDesktopLauncher {
     public static void main(String[] arg) {
-        LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-        config.width = 1440;
-        config.height = 810;
-        new LwjglApplication(new ReloadableGraphTestApplication(), config);
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setWindowedMode(1440, 810);
+        new Lwjgl3Application(new ReloadableGraphTestApplication(), config);
     }
 }


### PR DESCRIPTION
This PR changes the two desktop implementations `desktop` and `gdx-graph-test` to use Lwjgl3 instead lf Lwjgl, to fix the following crash on Linux

```
LwjglApplication] Couldn't initialize audio, disabling audio
java.lang.UnsatisfiedLinkError: /tmp/libgdxdaniele/dd5c1a65/liblwjgl64.so: /home/daniele/.sdkman/candidates/java/11.0.14-zulu/lib/libjawt.so: version `SUNWprivate_1.1' not found (required by /tmp/libgdxdaniele/dd5c1a65/liblwjgl64.so)
    at java.base/java.lang.ClassLoader$NativeLibrary.load0(Native Method)
    at java.base/java.lang.ClassLoader$NativeLibrary.load(ClassLoader.java:2442)
    at java.base/java.lang.ClassLoader$NativeLibrary.loadLibrary(ClassLoader.java:2498)
    at java.base/java.lang.ClassLoader.loadLibrary0(ClassLoader.java:2694)
    at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2627)
    at java.base/java.lang.Runtime.load0(Runtime.java:768)
    at java.base/java.lang.System.load(System.java:1837)
    at org.lwjgl.Sys$1.run(Sys.java:70)
    at java.base/java.security.AccessController.doPrivileged(Native Method)
    at org.lwjgl.Sys.doLoadLibrary(Sys.java:66)
    at org.lwjgl.Sys.loadLibrary(Sys.java:87)
    at org.lwjgl.Sys.<clinit>(Sys.java:117)
    at org.lwjgl.openal.AL.<clinit>(AL.java:59)
    at com.badlogic.gdx.backends.lwjgl.audio.OpenALLwjglAudio.<init>(OpenALLwjglAudio.java:71)
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication.createAudio(LwjglApplication.java:278)
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication.<init>(LwjglApplication.java:90)
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication.<init>(LwjglApplication.java:71)
    at com.gempukku.libgdx.graph.desktop.DesktopLauncher.main(DesktopLauncher.java:32)
Exception in thread "LWJGL Application" java.lang.NoClassDefFoundError: Could not initialize class org.lwjgl.Sys
    at org.lwjgl.opengl.Display.<clinit>(Display.java:135)
    at com.badlogic.gdx.backends.lwjgl.LwjglGraphics.setVSync(LwjglGraphics.java:646)
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:125)
```