### PR TITLE
Renames DesktopLauncher to GraphEditorLauncher

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -4,7 +4,7 @@ sourceCompatibility = 1.7
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["../core/assets"]
 
-project.ext.mainClassName = "com.gempukku.libgdx.graph.desktop.DesktopLauncher"
+project.ext.mainClassName = "com.gempukku.libgdx.graph.desktop.GraphEditorLauncher"
 project.ext.assetsDir = new File("../core/assets")
 
 task run(dependsOn: classes, type: JavaExec) {

--- a/desktop/src/com/gempukku/libgdx/graph/desktop/GraphEditorLauncher.java
+++ b/desktop/src/com/gempukku/libgdx/graph/desktop/GraphEditorLauncher.java
@@ -22,7 +22,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-public class DesktopLauncher {
+public class GraphEditorLauncher {
     public static void main(String[] arg) throws IOException {
         setupPlugins();
 


### PR DESCRIPTION
This helps when you have multiple run configurations, so you easily see what run configuration opens the graph editor.

Cool project! This is just a small change to check if the project accept external contributions :) 